### PR TITLE
Update dictionary lookup to use gem path by default

### DIFF
--- a/lib/textstat.rb
+++ b/lib/textstat.rb
@@ -1,6 +1,8 @@
 require 'text-hyphen'
 
 class TextStat
+  GEM_PATH = File.dirname(File.dirname(__FILE__))
+
   def self.char_count(text, ignore_spaces = true)
     text = text.delete(' ') if ignore_spaces
     text.length
@@ -152,7 +154,7 @@ class TextStat
   def self.difficult_words(text, language = 'en_us')
     require 'set'
     easy_words = Set.new
-    File.read("lib/dictionaries/#{language}.txt").each_line do |line|
+    File.read(File.join(dictionary_path, "#{language}.txt")).each_line do |line|
       easy_words << line.chop
     end
 
@@ -289,5 +291,13 @@ class TextStat
     else
       return "#{score.to_i - 1}th and #{score.to_i}th grade"
     end
+  end
+
+  def self.dictionary_path=(path)
+    @dictionary_path = path
+  end
+
+  def self.dictionary_path
+    @dictionary_path ||= File.join(TextStat::GEM_PATH, 'lib', 'dictionaries')
   end
 end

--- a/spec/textstat_spec.rb
+++ b/spec/textstat_spec.rb
@@ -158,5 +158,20 @@ describe TextStat do
       standard = TextStat.text_standard(@long_test)
       expect(standard).to eql '10th and 11th grade'
     end
+
+    describe '.dictionary_path' do
+      subject(:dictionary_path) { described_class.dictionary_path }
+
+      it 'returns the Gem dictionary path by default' do
+        gem_root = File.dirname(File.dirname(__FILE__))
+        default_path = File.join(gem_root, 'lib', 'dictionaries')
+        expect(dictionary_path).to eq default_path
+      end
+
+      it 'allows dictionary path to be overridden' do
+        described_class.dictionary_path = '/some/other/path'
+        expect(dictionary_path).to eq '/some/other/path'
+      end
+    end
   end
 end


### PR DESCRIPTION
When the gem is loaded in another ruby app, the current code requires that the app also have it's own version of the dictionary.

Proposed change adds accessor methods for the dictionary path, defaulting to the `textstat` gem path.
* Fixes loading of the dictionary when the `cwd` isn't the gem path
* Allows custom dictionary paths to be specified (if wanting to overload the `textstat` dictionaries?)

Note that this does change the default behaviour for anyone using the `textstat` gem (in another app) and they ARE overloading the dictionary. 