### PR TITLE
Fixed some calculation bugs and improve calculation readability

### DIFF
--- a/lib/textstat.rb
+++ b/lib/textstat.rb
@@ -23,7 +23,7 @@ class TextStat
     count = 0
     text.split(' ').each do |word|
       word_hyphenated = dictionary.visualise(word)
-      count += [1, word_hyphenated.count('-') + 1].max
+      count += word_hyphenated.count('-') + 1
     end
     count
   end
@@ -33,7 +33,7 @@ class TextStat
   end
 
   def self.avg_sentence_length(text)
-    asl = lexicon_count(text).to_f / sentence_count(text).to_f
+    asl = lexicon_count(text).to_f / sentence_count(text)
     asl.round(1)
   rescue ZeroDivisionError
     0.0
@@ -43,22 +43,22 @@ class TextStat
     syllable = syllable_count(text)
     words    = lexicon_count(text)
     begin
-      syllables_per_word = syllable.to_f / words.to_f
-      return syllables_per_word.round(1)
+      syllables_per_word = syllable.to_f / words
+      syllables_per_word.round(1)
     rescue ZeroDivisionError
-      return 0.0
+      0.0
     end
   end
 
   def self.avg_letter_per_word(text)
-    letters_per_word = char_count(text).to_f / lexicon_count(text).to_f
+    letters_per_word = char_count(text).to_f / lexicon_count(text)
     letters_per_word.round(2)
   rescue ZeroDivisionError
     0.0
   end
 
   def self.avg_sentence_per_word(text)
-    sentence_per_word = sentence_count(text).to_f / lexicon_count(text).to_f
+    sentence_per_word = sentence_count(text).to_f / lexicon_count(text)
     sentence_per_word.round(2)
   rescue ZeroDivisionError
     0.0
@@ -67,16 +67,14 @@ class TextStat
   def self.flesch_reading_ease(text)
     sentence_length    = avg_sentence_length(text)
     syllables_per_word = avg_syllables_per_word(text)
-    flesch = (
-    206.835 - (1.015 * sentence_length).to_f - (84.6 * syllables_per_word).to_f
-    )
+    flesch = 206.835 - 1.015 * sentence_length - 84.6 * syllables_per_word
     flesch.round(2)
   end
 
   def self.flesch_kincaid_grade(text)
     sentence_length = avg_sentence_length(text)
     syllables_per_word = avg_syllables_per_word(text)
-    flesch = (0.39 * sentence_length.to_f) + (11.8 * syllables_per_word.to_f) - 15.59
+    flesch = 0.39 * sentence_length + 11.8 * syllables_per_word - 15.59
     flesch.round(1)
   end
 
@@ -95,37 +93,35 @@ class TextStat
     if sentences >= 3
       begin
         polysyllab = polysyllab_count(text)
-        smog = (
-        (1.043 * (30 * (polysyllab / sentences))**0.5) + 3.1291)
-        return smog.round(1)
+        smog = 1.043 * Math.sqrt(30.0 * polysyllab / sentences) + 3.1291
+        smog.round(1)
       rescue ZeroDivisionError
-        return 0.0
+        0.0
       end
     else
-      return 0.0
+      0.0
     end
   end
 
   def self.coleman_liau_index(text)
-    letters   = (avg_letter_per_word(text) * 100).round(2)
+    letters = (avg_letter_per_word(text) * 100).round(2)
     sentences = (avg_sentence_per_word(text) * 100).round(2)
-    coleman   = ((0.058 * letters) - (0.296 * sentences) - 15.8).to_f
+    coleman = 0.0588 * letters - 0.296 * sentences - 15.8
     coleman.round(2)
   end
 
   def self.automated_readability_index(text)
-    chars     = char_count(text)
-    words     = lexicon_count(text)
+    chars = char_count(text)
+    words = lexicon_count(text)
     sentences = sentence_count(text)
     begin
-      a = chars.to_f / words.to_f
-      b = words.to_f / sentences.to_f
+      a = chars.to_f / words
+      b = words.to_f / sentences
 
-      readability = (
-      (4.71 * a.round(2) + (0.5 * b.round(2))) - 21.43)
-      return readability.round(1)
+      readability = 4.71 * a + 0.5 * b - 21.43
+      readability.round(1)
     rescue ZeroDivisionError
-      return 0.0
+      0.0
     end
   end
 
@@ -144,11 +140,9 @@ class TextStat
 
     text = text_list.join(' ')
 
-    number = ((easy_word * 1 + difficult_word * 3) / sentence_count(text)).to_f
-    if number <= 20
-      number -= 2
-    end
-    return number / 2
+    number = (easy_word * 1 + difficult_word * 3).to_f / sentence_count(text)
+    number -= 2 if number <= 20
+    number / 2
   end
 
   def self.difficult_words(text, language = 'en_us')
@@ -161,13 +155,11 @@ class TextStat
     text_list = text.downcase.gsub(/[^0-9a-z ]/i, '').split(' ')
     diff_words_set = Set.new
     text_list.each do |value|
-      unless easy_words.include? value
-        if syllable_count(value) > 1
-          diff_words_set.add(value)
-        end
-      end
+      next if easy_words.include? value
+
+      diff_words_set.add(value) if syllable_count(value) > 1
     end
-    return diff_words_set.length
+    diff_words_set.length
   end
 
   def self.dale_chall_readability_score(text)
@@ -175,44 +167,37 @@ class TextStat
     count = word_count - difficult_words(text)
 
     begin
-      per = count.to_f / word_count.to_f * 100
+      per = 100.0 * count / word_count
     rescue ZeroDivisionError
       return 0.0
     end
 
     difficult_words = 100 - per
-    score = (
-    (0.1579 * difficult_words)
-    + (0.0496 * avg_sentence_length(text)))
+    score = 0.1579 * difficult_words + 0.0496 * avg_sentence_length(text)
+    score += 3.6365 if difficult_words > 5
 
-    if difficult_words > 5
-      score += 3.6365
-    end
-    return score.round(2)
+    score.round(2)
   end
 
   def self.gunning_fog(text)
-    begin
-      per_diff_words = (
-      (difficult_words(text) / lexicon_count(text) * 100) + 5)
+    per_diff_words = 100.0 * difficult_words(text) / lexicon_count(text) + 5
+    grade = 0.4 * (avg_sentence_length(text) + per_diff_words)
 
-      grade = 0.4 * (avg_sentence_length(text) + per_diff_words)
-      return grade.round(2)
-    rescue ZeroDivisionError
-      return 0.0
-    end
+    grade.round(2)
+  rescue ZeroDivisionError
+    0.0
   end
 
   def self.lix(text)
     words = text.split(' ')
     words_length = words.length
-    long_words = words.select { |word| word.length > 6 }.count
+    long_words = words.count { |word| word.length > 6 }
 
-    per_long_words = (long_words * 100).to_f / words_length
+    per_long_words = 100.0 * long_words / words_length
     asl = avg_sentence_length(text)
     lix = asl + per_long_words
 
-    return lix.round(2)
+    lix.round(2)
   end
 
   def self.text_standard(text, float_output=nil)
@@ -287,9 +272,9 @@ class TextStat
     score = final_grade[0][0]
 
     if float_output
-      return score.to_f
+      score.to_f
     else
-      return "#{score.to_i - 1}th and #{score.to_i}th grade"
+      "#{score.to_i - 1}th and #{score.to_i}th grade"
     end
   end
 

--- a/spec/textstat_spec.rb
+++ b/spec/textstat_spec.rb
@@ -116,22 +116,22 @@ describe TextStat do
 
     it 'should return the correct smog index' do
       index = TextStat.smog_index(@long_test)
-      expect(index).to eql 11.2
+      expect(index).to eql 12.5
     end
 
     it 'should return the correct Coleman–Liau index' do
       index = TextStat.coleman_liau_index(@long_test)
-      expect(index).to eql 10.28
+      expect(index).to eql 10.65
     end
 
     it 'should return the correct automated readability index' do
       index = TextStat.automated_readability_index(@long_test)
-      expect(index).to eql 12.3
+      expect(index).to eql 12.4
     end
 
     it 'should return the correct linsear write formula result' do
       result = TextStat.linsear_write_formula(@long_test)
-      expect(result).to eql 14.5
+      expect(result).to eql 14.875
     end
 
     it 'should return the correct difficult words result' do
@@ -141,12 +141,12 @@ describe TextStat do
 
     it 'should return the correct Dale–Chall readability score' do
       score = TextStat.dale_chall_readability_score(@long_test)
-      expect(score).to eql 4.79
+      expect(score).to eql 7.25
     end
 
     it 'should return the correct Gunning fog score' do
       score = TextStat.gunning_fog(@long_test)
-      expect(score).to eql 11.32
+      expect(score).to eql 17.56
     end
 
     it 'should return the correct Lix readability test score' do


### PR DESCRIPTION
Fixes #31 

Fix calculation bug in Dale/Chall readability score
Remove unnecessary `max` from syllable count
Remove unnecessary cast from avg_sentence_length
Remove unnecessary cast from avg_syllables_per_word
Remove unnecessary cast from avg_letter_per_word
Remove unnecessary cast from avg_sentence_per_word
Remove unnecessary cast from flesch_reading_ease
Remove unnecessary cast from flesch_kincaid_grade
Improved readability of smog_index
Remove unnecessary cast and fixed scaler typo in coleman_liau_index
Improved readability and unnecessary rounding from automated_readability_index
Improved readability of linsear_write_formula
Improved readability of difficult_words
Improved readability of gunning_fog
Improved readability of lix